### PR TITLE
Fix Link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Directory
 
 Welcome to Hack Club APAC Directory, a Directory like never before 🚀
-This is the frontend of the Directory, deployed at [https://apacdirectory.hackclub.com](apacdirectory.hackclub.com).
+This is the frontend of the Directory, deployed at https://apacdirectory.hackclub.com.
 
 ## Docs/Guide
 


### PR DESCRIPTION
The current link in `README.md` leads to `https://github.com/hackclub/apac-directory/blob/main/apacdirectory.hackclub.com`, which is definitely unexpected. This pull request fixes the link to ensure that it directly goes to `https://apacdirectory.hackclub.com`.